### PR TITLE
added Startpage.com to search engines

### DIFF
--- a/app/src/main/res/values/search_engines.xml
+++ b/app/src/main/res/values/search_engines.xml
@@ -21,6 +21,7 @@
         <item>DuckDuckGo</item>
         <item>Google</item>
         <item>Google encrypted</item>
+        <item>Startpage</item>
         <item>Yahoo</item>
         <item>Yandex</item>
     </string-array>
@@ -31,6 +32,7 @@
         <item>https://duckduckgo.com/?q={searchTerms}</item>
         <item>https://google.com/search?ie=UTF-8&amp;source=android-browser&amp;q={searchTerms}</item>
         <item>https://encrypted.google.com/search?q={searchTerms}</item>
+        <item>https://www.startpage.com/do/dsearch?query={searchTerms}</item>
         <item>https://search.yahoo.com/p={searchTerms}</item>
         <item>https://yandex.com/?q={searchTerms}</item>
     </string-array>


### PR DESCRIPTION
It's a bit more privacy focused than DDG and uses Google search results.
Would have built you a suggestion provider as well, but they don't have that.